### PR TITLE
Mark overriding member functions as 'override'

### DIFF
--- a/src/lib/SDAParser.hxx
+++ b/src/lib/SDAParser.hxx
@@ -74,7 +74,7 @@ public:
     m_password=passwd;
   }
   //! checks if the document header is correct (or not)
-  bool checkHeader(STOFFHeader *header, bool strict=false);
+  bool checkHeader(STOFFHeader *header, bool strict=false) override;
 
   // the main parse function
   void parse(librevenge::RVNGDrawingInterface *documentInterface) final;

--- a/src/lib/SDCParser.hxx
+++ b/src/lib/SDCParser.hxx
@@ -74,10 +74,10 @@ public:
     m_password=passwd;
   }
   //! checks if the document header is correct (or not)
-  bool checkHeader(STOFFHeader *header, bool strict=false);
+  bool checkHeader(STOFFHeader *header, bool strict=false) override;
 
   // the main parse function
-  void parse(librevenge::RVNGSpreadsheetInterface *documentInterface);
+  void parse(librevenge::RVNGSpreadsheetInterface *documentInterface) override;
 
 protected:
   //! creates the listener which will be associated to the document

--- a/src/lib/SDGParser.hxx
+++ b/src/lib/SDGParser.hxx
@@ -74,10 +74,10 @@ public:
     m_password=passwd;
   }
   //! checks if the document header is correct (or not)
-  bool checkHeader(STOFFHeader *header, bool strict=false);
+  bool checkHeader(STOFFHeader *header, bool strict=false) override;
 
   // the main parse function
-  void parse(librevenge::RVNGDrawingInterface *documentInterface);
+  void parse(librevenge::RVNGDrawingInterface *documentInterface) override;
 
 protected:
   //! creates the listener which will be associated to the document

--- a/src/lib/SDWParser.hxx
+++ b/src/lib/SDWParser.hxx
@@ -74,10 +74,10 @@ public:
     m_password=passwd;
   }
   //! checks if the document header is correct (or not)
-  bool checkHeader(STOFFHeader *header, bool strict=false);
+  bool checkHeader(STOFFHeader *header, bool strict=false) override;
 
   // the main parse function
-  void parse(librevenge::RVNGTextInterface *documentInterface);
+  void parse(librevenge::RVNGTextInterface *documentInterface) override;
 
 protected:
   //! creates the listener which will be associated to the document

--- a/src/lib/SDXParser.hxx
+++ b/src/lib/SDXParser.hxx
@@ -74,10 +74,10 @@ public:
     m_password=passwd;
   }
   //! checks if the document header is correct (or not)
-  bool checkHeader(STOFFHeader *header, bool strict=false);
+  bool checkHeader(STOFFHeader *header, bool strict=false) override;
 
   // the main parse function
-  void parse(librevenge::RVNGTextInterface *documentInterface);
+  void parse(librevenge::RVNGTextInterface *documentInterface) override;
 
 protected:
   //! inits all internal variables

--- a/src/lib/STOFFGraphicDecoder.hxx
+++ b/src/lib/STOFFGraphicDecoder.hxx
@@ -53,17 +53,17 @@ public:
     : STOFFPropertyHandler()
     , m_output(output) { }
   /** destructor */
-  ~STOFFGraphicDecoder() {}
+  ~STOFFGraphicDecoder() override {}
 
   /** insert an element */
-  void insertElement(const char *psName);
+  void insertElement(const char *psName) override;
   /** insert an element ( with a librevenge::RVNGPropertyList ) */
-  void insertElement(const char *psName, const librevenge::RVNGPropertyList &xPropList);
+  void insertElement(const char *psName, const librevenge::RVNGPropertyList &xPropList) override;
   /** insert an element ( with a librevenge::RVNGPropertyListVector parameter ) */
   void insertElement(const char *psName, const librevenge::RVNGPropertyList &xPropList,
                      const librevenge::RVNGPropertyListVector &vector);
   /** insert a sequence of character */
-  void characters(const librevenge::RVNGString &sCharacters)
+  void characters(const librevenge::RVNGString &sCharacters) override
   {
     if (!m_output) return;
     m_output->insertText(sCharacters);

--- a/src/lib/SWFieldManager.cxx
+++ b/src/lib/SWFieldManager.cxx
@@ -932,10 +932,10 @@ public:
     , m_text(text) {}
 
   //! destructor
-  virtual ~SubDocument() {}
+  ~SubDocument() override {}
 
   //! operator!=
-  virtual bool operator!=(STOFFSubDocument const &doc) const final
+  bool operator!=(STOFFSubDocument const &doc) const final
   {
     if (STOFFSubDocument::operator!=(doc)) return true;
     SubDocument const *sDoc = dynamic_cast<SubDocument const *>(&doc);

--- a/src/lib/StarAttribute.cxx
+++ b/src/lib/StarAttribute.cxx
@@ -71,7 +71,7 @@ public:
   {
   }
   //! destructor
-  ~StarAttributeXML();
+  ~StarAttributeXML() override;
   //! create a new attribute
   std::shared_ptr<StarAttribute> create() const final
   {

--- a/src/lib/StarObjectChart.hxx
+++ b/src/lib/StarObjectChart.hxx
@@ -62,7 +62,7 @@ public:
   //! constructor
   StarObjectChart(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectChart();
+  ~StarObjectChart() override;
   //! try to parse the current object
   bool parse();
 

--- a/src/lib/StarObjectDraw.hxx
+++ b/src/lib/StarObjectDraw.hxx
@@ -64,7 +64,7 @@ public:
   //! constructor
   StarObjectDraw(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectDraw();
+  ~StarObjectDraw() override;
   //! try to parse the current object
   bool parse();
 

--- a/src/lib/StarObjectModel.hxx
+++ b/src/lib/StarObjectModel.hxx
@@ -65,7 +65,7 @@ public:
   //! constructor
   StarObjectModel(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectModel();
+  ~StarObjectModel() override;
   //! try to read a SdrModel zone: "DrMd"
   bool read(StarZone &zone);
 

--- a/src/lib/StarObjectNumericRuler.hxx
+++ b/src/lib/StarObjectNumericRuler.hxx
@@ -66,7 +66,7 @@ public:
   //! constructor
   StarObjectNumericRuler(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectNumericRuler();
+  ~StarObjectNumericRuler() override;
   //! try to read a number format zone : 'n'
   static bool readLevel(StarZone &zone, STOFFListLevel &level);
   //! try to read a attribute format : ATTR_EE_PARA_BULLET

--- a/src/lib/StarObjectPageStyle.hxx
+++ b/src/lib/StarObjectPageStyle.hxx
@@ -65,7 +65,7 @@ public:
   //! constructor
   StarObjectPageStyle(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectPageStyle();
+  ~StarObjectPageStyle() override;
   //! try to read a PageStyle zone
   bool read(StarZone &zone);
 

--- a/src/lib/StarObjectSmallGraphic.cxx
+++ b/src/lib/StarObjectSmallGraphic.cxx
@@ -1069,7 +1069,7 @@ public:
   {
   }
   //! destructor
-  ~SdrGraphicGraph();
+  ~SdrGraphicGraph() override;
   //! basic print function
   std::string print() const final
   {
@@ -1339,7 +1339,7 @@ public:
   {
   }
   //! destructor
-  ~SdrGraphicPage();
+  ~SdrGraphicPage() override;
   //! basic print function
   std::string print() const final
   {
@@ -1546,9 +1546,9 @@ public:
     for (int i=0; i<5; ++i) m_booleans[i]=false;
   }
   //! destructor
-  ~SDUDGraphicAnimation();
+  ~SDUDGraphicAnimation() override;
   //! basic print function
-  virtual std::string print() const
+  std::string print() const override
   {
     std::stringstream s;
     s << *this << ",";

--- a/src/lib/StarObjectSmallGraphic.hxx
+++ b/src/lib/StarObjectSmallGraphic.hxx
@@ -79,7 +79,7 @@ public:
   //! constructor
   StarObjectSmallGraphic(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectSmallGraphic();
+  ~StarObjectSmallGraphic() override;
   //! try to read a object zone: "DrOb'
   bool readSdrObject(StarZone &zone);
   //! try to send a object to the listener

--- a/src/lib/StarObjectSmallText.hxx
+++ b/src/lib/StarObjectSmallText.hxx
@@ -61,7 +61,7 @@ public:
   //! constructor
   StarObjectSmallText(StarObject const &orig, bool duplicateState);
   //! destructor
-  virtual ~StarObjectSmallText();
+  ~StarObjectSmallText() override;
 
   //! try to read a small text object
   bool read(StarZone &zone, long lastPos);

--- a/src/lib/StarObjectSpreadsheet.cxx
+++ b/src/lib/StarObjectSpreadsheet.cxx
@@ -269,7 +269,7 @@ public:
     setPosition(pos);
   }
   //! destructor
-  ~Cell();
+  ~Cell() override;
   //! the cell content
   STOFFCellContent m_content;
   //! the text zone(if set)
@@ -342,7 +342,7 @@ public:
   {
   }
   //! destructor
-  ~Table();
+  ~Table() override;
   //! returns the load version
   int getLoadingVersion() const
   {
@@ -508,7 +508,7 @@ public:
   ~SubDocument() final {}
 
   //! operator!=
-  bool operator!=(STOFFSubDocument const &doc) const
+  bool operator!=(STOFFSubDocument const &doc) const override
   {
     if (STOFFSubDocument::operator!=(doc)) return true;
     SubDocument const *sDoc = dynamic_cast<SubDocument const *>(&doc);

--- a/src/lib/StarPageAttribute.cxx
+++ b/src/lib/StarPageAttribute.cxx
@@ -105,7 +105,7 @@ public:
   {
   }
   //! destructor
-  ~StarPAttributeInt();
+  ~StarPAttributeInt() override;
   //! add to a page
   // void addTo(StarState &state, std::set<StarAttribute const *> &/*done*/) const final;
   //! create a new attribute

--- a/src/lib/StarParagraphAttribute.cxx
+++ b/src/lib/StarParagraphAttribute.cxx
@@ -626,7 +626,7 @@ public:
   //! add to a para
   void addTo(StarState &state, std::set<StarAttribute const *> &/*done*/) const final;
   //! debug function to print the data
-  virtual void printData(libstoff::DebugStream &o) const
+  void printData(libstoff::DebugStream &o) const override
   {
     o << m_debugName << "=[";
     for (auto const &t : m_tabList)


### PR DESCRIPTION
This does not affect the generated code (API or ABI), but:

1) Makes sure that in case the signature of one of these functions would
change by accident, the build breaks as the function no longer overrides
a base function.

2) Makes the code readable by explicitly marking all overriding
functions as 'override', where previously the reader had to read the
interface of the base class(es) as well to find out if the function is
virtual or not.

3) Since 'override' implies 'virtual', remove the 'virtual' keyword
where 'override' is present.