### PR TITLE
Fix equality operator arguments

### DIFF
--- a/src/lib/STOFFChart.cxx
+++ b/src/lib/STOFFChart.cxx
@@ -227,7 +227,7 @@ void STOFFChart::sendChart(STOFFSpreadsheetListenerPtr &listener, librevenge::RV
 
   // legend
   if (m_legend.m_show) {
-    bool autoPlace=m_legendPosition==STOFFBox2f()||m_dimension==STOFFVec2i();
+    bool autoPlace=m_legendPosition==STOFFBox2f()||m_dimension==STOFFVec2f();
     style=librevenge::RVNGPropertyList();
     m_legend.addStyleTo(style);
     style.insert("librevenge:chart-id", styleId);
@@ -267,7 +267,7 @@ void STOFFChart::sendChart(STOFFSpreadsheetListenerPtr &listener, librevenge::RV
   }
   // plot area
   style=librevenge::RVNGPropertyList();
-  bool autoPlace=m_plotAreaPosition==STOFFBox2f()||m_dimension==STOFFVec2i();
+  bool autoPlace=m_plotAreaPosition==STOFFBox2f()||m_dimension==STOFFVec2f();
   m_plotAreaStyle.addTo(style);
   style.insert("librevenge:chart-id", styleId);
   style.insert("chart:include-hidden-cells","false");


### PR DESCRIPTION
...which avoids overload resolution ambiguities in C++20, when a synthesized
candidate of operator == for a reversed-argument rewrite conflicts with the
actual operator ==, as one is a template specialization for int and the other
for float.  (As observed with recent Clang 10 trunk with -std=c++2a when
building libstaroffice as part of LibreOffice:

> STOFFChart.cxx:230:63: error: use of overloaded operator '==' is ambiguous (with operand types 'STOFFVec2f' (aka 'STOFFVec2<float>') and 'STOFFVec2i' (aka 'STOFFVec2<int>'))
>     bool autoPlace=m_legendPosition==STOFFBox2f()||m_dimension==STOFFVec2i();
>                                                    ~~~~~~~~~~~^ ~~~~~~~~~~~~
> ./libstaroffice_internal.hxx:687:8: note: candidate function
>   bool operator==(STOFFVec2<T> const &p) const
>        ^
> ./libstaroffice_internal.hxx:687:8: note: candidate function (with reversed parameter order)
> STOFFChart.cxx:270:63: error: use of overloaded operator '==' is ambiguous (with operand types 'STOFFVec2f' (aka 'STOFFVec2<float>') and 'STOFFVec2i' (aka 'STOFFVec2<int>'))
>   bool autoPlace=m_plotAreaPosition==STOFFBox2f()||m_dimension==STOFFVec2i();
>                                                    ~~~~~~~~~~~^ ~~~~~~~~~~~~
> ./libstaroffice_internal.hxx:687:8: note: candidate function
>   bool operator==(STOFFVec2<T> const &p) const
>        ^
> ./libstaroffice_internal.hxx:687:8: note: candidate function (with reversed parameter order)

)